### PR TITLE
Feature/sorting companies by priority

### DIFF
--- a/app/assets/stylesheets/admins/companies/companies_form.scss
+++ b/app/assets/stylesheets/admins/companies/companies_form.scss
@@ -1,12 +1,54 @@
 .short-fields {
   display: flex;
-  flex-flow: row wrap;
+  flex-wrap: nowrap;
+  flex-direction: row;
   justify-content: space-between;
   margin: 20px 0px;
 
-  @media screen and (max-width: 640px) {
-    justify-content: center;
-    flex-direction: column;
+  .input {
+    display: flex;
+    flex-flow: column nowrap;
+    width: 17%;
+    margin: 20px;
+
+    &:first-child {
+      margin: 20px 20px 20px 0;
+    }
+
+    &:last-child {
+      width: 10%;
+      min-width: 53px;
+      margin: 20px 0 20px 20px;
+    }
+  }
+
+  @media screen and (max-width: 700px) {
+    flex-wrap: wrap;
+
+    .input {
+      &:nth-child(4) {
+        margin-right: 0;
+      }
+
+      &:nth-child(5) {
+        margin-left: 0;
+      }
+
+      &:last-child {
+        margin-left: 0;
+      }
+    }
+  }
+
+  @media screen and (max-width: 416px) {
+    .input {
+      width: 40%;
+      margin: 20px 0;
+
+      &:last-child {
+        width: 40%;
+      }
+    }
   }
 
   .select-dropdown {
@@ -15,13 +57,13 @@
     background-color: $white-color;
     width: 100%;
     padding: 5px;
-    border: 1px solid #9e9e9e;
+    border: 1px solid $scrool-gray-color;
     border-radius: 10px;
     font-family: roboto, sans-serif;
 
     &:active,
     &:focus {
-      border: 1px solid #003087;
+      border: 1px solid $blue-filter-color;
       outline: 1px solid $border-color;
       box-shadow: 0 1px 0 0 $border-color;
     }
@@ -36,7 +78,7 @@
       height: 0;
       border-left: 5px solid transparent;
       border-right: 5px solid transparent;
-      border-top: 5px solid #aaa;
+      border-top: 5px solid $gray-color;
     }
   }
 }
@@ -87,13 +129,13 @@
       height: 60px;
       width: 295px;
       min-width: 295px;
-      background: white;
+      background: $white-color;
       border: 4px solid $background-color-title;
       border-radius: 30px;
       
       transition: background-color .2s ease-out;
       cursor: pointer;
-    
+
       &:hover {
         background-color: $background-color-title;
 
@@ -101,7 +143,7 @@
           color: $white-color;
         }
       }
-    
+
       &:focus {
         background-color: $admin-background-color-button;
       }
@@ -110,7 +152,7 @@
         position: absolute;
         padding-top: 15px;
       }
-    
+
       label {
         display: flex;
         align-items: center;
@@ -131,7 +173,7 @@
       margin: 10px 0px 10px 10px;
       width: 120px;
       height: 120px;
-      border: 1px solid rgb(118, 118, 118);
+      border: 1px solid $dark-grey-text;
       border-radius: 10px;
       background-color: $light-grey-text;
 

--- a/app/controllers/admins/companies_controller.rb
+++ b/app/controllers/admins/companies_controller.rb
@@ -58,7 +58,8 @@ module Admins
                                       :grants_count,
                                       :text_about,
                                       :media_file,
-                                      :language)
+                                      :language,
+                                      :priority)
     end
   end
 end

--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -2,7 +2,7 @@
 
 class CompaniesController < ApplicationController
   def index
-    @companies = Company.includes(media_file_attachment: :blob).in_language(extract_locale)
+    @companies = Company.includes(media_file_attachment: :blob).in_language(extract_locale).order_by_priority
     @articles = Article.published.in_language(extract_locale).sorted_desc
     @documents = Attachment.all
   end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -16,7 +16,8 @@ class Company < ApplicationRecord
             :clients_count,
             :grants_count,
             :text_about,
-            :language, presence: true
+            :language,
+            :priority, presence: true
   validates :start_year, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: Date.today.year }
   validates :projects_count,
             :clients_count,
@@ -24,6 +25,8 @@ class Company < ApplicationRecord
   validates :text_about, length: { in: 20..1000 }
   validates :media_file, attached: true, content_type: %i[png jpg jpeg],
                          size: { less_than: 5.megabytes, message: 'is too large' }
+  validates :priority, numericality: { only_integer: true }
 
   scope :in_language, ->(language) { where(language: language) }
+  scope :order_by_priority, -> { order(priority: :asc) }
 end

--- a/app/views/admins/companies/_form.html.erb
+++ b/app/views/admins/companies/_form.html.erb
@@ -30,6 +30,11 @@
                      input_html: { class: 'form-input' },
                      placeholder: t('admins.companies.views.placeholders.grants_count'),
                      error_html: { class: 'error-form-input' } %>
+  <%= f.input :priority, label: t('admins.companies.views.labels.priority'),
+                     label_html: { class: 'name-field-form' },
+                     input_html: { class: 'form-input' },
+                     placeholder: t('admins.companies.views.placeholders.priority'),
+                     error_html: { class: 'error-form-input' } %>
   <%= f.input :language, label: t('admins.companies.views.labels.language'),
                      label_html: { class: 'name-field-form' },
                      input_html: { class: 'select-dropdown' },

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,6 +130,7 @@ en:
           logo: 'Logo'
           language: 'Lang.'
           functions: 'Functions'
+          priority: 'Priority'
         buttons:
           new_company: 'Add company'
           view: 'View'
@@ -147,6 +148,7 @@ en:
           clients_count: 'Type the number of customers here...'
           grants_count: 'Type the number of grants here...'
           text_about: 'Type company information here...'
+          priority: 'Display priority'
         hints:
           logo_present: 'Logo present'
           logo_absent: 'Logo absent'

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -153,6 +153,7 @@ uk:
           logo: 'Логотип'
           language: 'Мова'
           functions: 'Функції'
+          priority: 'Пріоритет'
         buttons:
           new_company: 'Додати компанію'
           view: 'Переглянути'
@@ -170,6 +171,7 @@ uk:
           clients_count: 'Введіть кількість клієнтів тут...'
           grants_count: 'Введіть кількість грантів тут...'
           text_about: 'Введіть інформацію про компанію тут...'
+          priority: 'Порядок відображення'
         hints:
           logo_present: 'Логотип наявний'
           logo_absent: 'Логотип відсутній'

--- a/db/migrate/20220911183728_add_priority_to_company.rb
+++ b/db/migrate/20220911183728_add_priority_to_company.rb
@@ -1,0 +1,5 @@
+class AddPriorityToCompany < ActiveRecord::Migration[6.0]
+  def change
+    add_column :companies, :priority, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_10_175816) do
+ActiveRecord::Schema.define(version: 2022_09_11_183728) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 2022_09_10_175816) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "language", default: 0
+    t.integer "priority", default: 0, null: false
   end
 
   create_table "documents", force: :cascade do |t|

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     projects_count { rand(1..100) }
     clients_count { rand(1..100) }
     grants_count { rand(1..100) }
+    priority { rand(1..100) }
     text_about { Faker::Lorem.sentences(number: 10).join }
     media_file { Rack::Test::UploadedFile.new('spec/files/f.jpg', 'image/jpg') }
 
@@ -23,6 +24,7 @@ FactoryBot.define do
     projects_count { 0 }
     clients_count { nil }
     grants_count { -1 }
+    priority { 0.5 }
     text_about { Faker::Lorem.characters(number: 10) }
     media_file { Rack::Test::UploadedFile.new('spec/files/image') }
     language { Company::LANGUAGES.keys.sample }

--- a/spec/features/companies/admins_companies.rb
+++ b/spec/features/companies/admins_companies.rb
@@ -22,6 +22,7 @@ RSpec.describe 'Company', type: :feature do
       fill_in I18n.t('admins.companies.views.labels.projects_count'), with: valid_company[:projects_count]
       fill_in I18n.t('admins.companies.views.labels.clients_count'), with: valid_company[:clients_count]
       fill_in I18n.t('admins.companies.views.labels.grants_count'), with: valid_company[:grants_count]
+      fill_in I18n.t('admins.companies.views.labels.priority'), with: valid_company[:priority]
       select valid_company[:language], from: 'company_language'
       fill_in I18n.t('admins.companies.views.labels.text_about'), with: valid_company[:text_about]
       attach_file(I18n.t('admins.companies.views.buttons.upload_logo'), "#{Rails.root}/spec/files/f.jpg")
@@ -32,6 +33,7 @@ RSpec.describe 'Company', type: :feature do
       expect(page).to have_content(valid_company[:projects_count])
       expect(page).to have_content(valid_company[:clients_count])
       expect(page).to have_content(valid_company[:grants_count])
+      expect(page).to have_content(valid_company[:priority])
       expect(page).to have_content(valid_company[:language])
       expect(page).to have_content(valid_company[:text_about])
       expect(page).to have_content(I18n.t('admins.companies.views.hints.logo_present'))
@@ -45,6 +47,7 @@ RSpec.describe 'Company', type: :feature do
       fill_in I18n.t('admins.companies.views.labels.projects_count'), with: invalid_company[:projects_count]
       fill_in I18n.t('admins.companies.views.labels.clients_count'), with: invalid_company[:clients_count]
       fill_in I18n.t('admins.companies.views.labels.grants_count'), with: invalid_company[:grants_count]
+      fill_in I18n.t('admins.companies.views.labels.priority'), with: invalid_company[:priority]
       fill_in I18n.t('admins.companies.views.labels.text_about'), with: invalid_company[:text_about]
       attach_file(I18n.t('admins.companies.views.buttons.upload_logo'), "#{Rails.root}/spec/files/image")
       expect { click_button I18n.t('admins.companies.views.buttons.create_company') }.not_to(change { Company.count })
@@ -72,6 +75,7 @@ RSpec.describe 'Company', type: :feature do
       fill_in I18n.t('admins.companies.views.labels.projects_count'), with: valid_company[:projects_count]
       fill_in I18n.t('admins.companies.views.labels.clients_count'), with: valid_company[:clients_count]
       fill_in I18n.t('admins.companies.views.labels.grants_count'), with: valid_company[:grants_count]
+      fill_in I18n.t('admins.companies.views.labels.priority'), with: valid_company[:priority]
       select valid_company[:language], from: 'company_language'
       fill_in I18n.t('admins.companies.views.labels.text_about'), with: valid_company[:text_about]
       attach_file(I18n.t('admins.companies.views.buttons.upload_logo'), "#{Rails.root}/spec/files/pr.jpg")
@@ -82,6 +86,7 @@ RSpec.describe 'Company', type: :feature do
       expect(page).to have_content(valid_company[:projects_count])
       expect(page).to have_content(valid_company[:clients_count])
       expect(page).to have_content(valid_company[:grants_count])
+      expect(page).to have_content(valid_company[:priority])
       expect(page).to have_content(valid_company[:language])
       expect(page).to have_content(valid_company[:text_about])
       expect(page).to have_content(I18n.t('admins.companies.views.hints.logo_present'))
@@ -95,6 +100,7 @@ RSpec.describe 'Company', type: :feature do
       fill_in I18n.t('admins.companies.views.labels.projects_count'), with: invalid_company[:projects_count]
       fill_in I18n.t('admins.companies.views.labels.clients_count'), with: invalid_company[:clients_count]
       fill_in I18n.t('admins.companies.views.labels.grants_count'), with: invalid_company[:grants_count]
+      fill_in I18n.t('admins.companies.views.labels.priority'), with: invalid_company[:priority]
       select invalid_company[:language], from: 'company_language'
       fill_in I18n.t('admins.companies.views.labels.text_about'), with: invalid_company[:text_about]
       attach_file(I18n.t('admins.companies.views.buttons.upload_logo'), "#{Rails.root}/spec/files/image")

--- a/spec/features/companies/companies_spec.rb
+++ b/spec/features/companies/companies_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Company', type: :feature do
   let(:admin) { create(:user, :super_admin) }
-  let!(:company) { create(:company, :uk) }
+  let!(:company_list) { create_list(:company, 2) }
   let!(:news_list) { create_list(:article, 9, :published, :uk) }
   let!(:docs_list) { create_list(:attachment, 12) }
 
@@ -15,11 +15,14 @@ RSpec.describe 'Company', type: :feature do
   context 'when user visits company page' do
     it 'index page - shows company part' do
       expect(page).to have_current_path companies_path(locale: I18n.locale)
-      expect(page).to have_content(Date.today.year - company.start_year)
-      expect(page).to have_content(company.projects_count)
-      expect(page).to have_content(company.clients_count)
-      expect(page).to have_content(company.grants_count)
-      expect(page).to have_content(company.text_about)
+      company_list.each do |company|
+        expect(page).to have_content(company.name)
+        expect(page).to have_content(Date.today.year - company.start_year)
+        expect(page).to have_content(company.projects_count)
+        expect(page).to have_content(company.clients_count)
+        expect(page).to have_content(company.grants_count)
+        expect(page).to have_content(company.text_about)
+      end
     end
 
     it 'index page - shows news part' do
@@ -64,6 +67,17 @@ RSpec.describe 'Company', type: :feature do
       find('a', text: docs_list.first.name).click
       expect(page).to have_current_path admins_attachment_path(docs_list.first, locale: I18n.locale)
       expect(page).to have_content(docs_list.first.name)
+    end
+  end
+
+  context 'when showing by priority' do
+    it 'shows by prioryty' do
+      expect(page).to have_current_path companies_path(locale: I18n.locale)
+      actual_company_list = []
+      company_list.each do |company|
+        actual_company_list << find('.company-name', text: company.name).text
+      end
+      expect(actual_company_list).to eq(company_list.pluck(:name))
     end
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Company, type: :model do
   describe 'validations' do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:start_year) }
+    it { should validate_presence_of(:priority) }
     it { should validate_numericality_of(:start_year).only_integer }
+    it { should validate_numericality_of(:priority).only_integer }
     it { should validate_numericality_of(:start_year).is_less_than_or_equal_to(Date.today.year) }
     it { should validate_numericality_of(:start_year).is_greater_than(0) }
     it { should_not allow_value(-1).for(:start_year) }


### PR DESCRIPTION
Show companies on the index page (client side) by priority.

- [x] Add new column 'priority' to Companies table
- [x] Add validations for new column to model. Add sorting
- [x] Update controller - use sorting
- [x] Add some tests

[https://trello.com/c/x6kGHuEV/108-add-sorting-companies-by-priority](https://trello.com/c/x6kGHuEV/108-add-sorting-companies-by-priority)

![screenshot-127 0 0 1_3000-2022 09 12-00_59_23](https://user-images.githubusercontent.com/57721223/189550706-3862a733-11ca-4482-9571-91602279fd8e.png)

![screenshot-127 0 0 1_3000-2022 09 12-01_00_22](https://user-images.githubusercontent.com/57721223/189550711-14f86f0d-6308-4eed-838b-c552fe922003.png)

![Screenshot from 2022-09-12 01-02-17](https://user-images.githubusercontent.com/57721223/189550712-4968f37d-199c-4829-a470-19c6231f9873.png)